### PR TITLE
Update course_styles.user.css details

### DIFF
--- a/course_styles.user.css
+++ b/course_styles.user.css
@@ -78,7 +78,9 @@ div.portfolioRightPage #pageTitleDiv h1#pageTitleHeader span {
 #content.contentBox ul.contentListPlain > li > .details {
   color: #b9bbbe !important;
 }
-
+.details:not(:hover) div div{
+    color: #b9bbbe
+}
 .announcementList span {
   color: #b9bbbe !important;
 }


### PR DESCRIPTION
course details now have readable text both during hover and normaly,
normal:
![image](https://user-images.githubusercontent.com/71447016/109806358-e81fd800-7c24-11eb-8f69-3327938b0629.png)
hover:
![image](https://user-images.githubusercontent.com/71447016/109806427-fcfc6b80-7c24-11eb-8d08-fd81c1f8014f.png)

